### PR TITLE
Fix iterator to handle scenario when only one node is available

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -279,25 +279,28 @@ func (t *treeImpl[K, D]) getNextNode(n *node[K, D]) *node[K, D] {
 	}
 
 	x := t.root_
-	if n != nil {
-		x = n
-	}
-	l := x
-
-	for x != nil {
-		if x.bitpos_ < l.bitpos_ {
-			l = x
-			x = l.right_
-		} else {
-			l = x
-			if l.left_ != nil {
-				x = l.left_
-			} else {
-				x = l.right_
-			}
+	if n != nil || x.intnode_ {
+		if n != nil {
+			x = n
 		}
-		if x != nil && x.bitpos_ > l.bitpos_ && !x.intnode_ {
-			break
+
+		l := x
+
+		for x != nil {
+			if x.bitpos_ < l.bitpos_ {
+				l = x
+				x = l.right_
+			} else {
+				l = x
+				if l.left_ != nil {
+					x = l.left_
+				} else {
+					x = l.right_
+				}
+			}
+			if x != nil && x.bitpos_ > l.bitpos_ && !x.intnode_ {
+				break
+			}
 		}
 	}
 

--- a/simple_test.go
+++ b/simple_test.go
@@ -109,6 +109,31 @@ func TestSimpleTreeAll(t *testing.T) {
 	}
 }
 
+// TestSimpleTreeAll tests the All iterator.
+func TestSimpleTreeAll_2(t *testing.T) {
+	tree := NewSimpleTree[[]string]()
+	//keys := []string{"foo", "bar", "baz"}
+	keys := []string{"user"}
+	vals := []string{"foo", "bar", "baz"}
+	for _, k := range keys {
+		tree.Insert(k, vals)
+	}
+
+	found := make(map[string][]string)
+	for k, v := range tree.All() {
+		found[k] = v
+	}
+
+	for _, k := range keys {
+		newVals := found[k]
+		for i, v := range vals {
+			if newVals[i] != v {
+				t.Errorf("All: expected %s=%v, got %v", k, v, newVals[i])
+			}
+		}
+	}
+}
+
 // TestSimpleTreeEmpty tests operations on an empty tree.
 func TestSimpleTreeEmpty(t *testing.T) {
 	tree := NewSimpleTree[int]()


### PR DESCRIPTION
Current logic of getnext node failed to return if the root node is not the internal node, typically unable to return any value when only one is present in the tree

Also added testcase to cover the same in future