### PR TITLE
Simplify and address performance improvements in createNew

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -16,8 +16,6 @@
 
 package patricia
 
-import "reflect"
-
 // Key is an interface that must be implemented by any key type used in the Patricia tree.
 // It provides methods to get the bit length of the key and to retrieve a byte at a given position.
 type Key interface {
@@ -65,21 +63,10 @@ type treeImpl[K Key, D any] struct {
 	root_     *node[K, D] // Pointer to the root node of the tree
 }
 
-// createNew creates a new node of type node[K, D] using reflection.
-// This is used to generically allocate nodes for any key/data type.
+// createNew creates a new node of type node[K, D].
+// This is a simple allocation function that returns a zero-initialized node.
 func createNew[K Key, D any]() *node[K, D] {
-	var t node[K, D]
-	typeOfT := reflect.TypeOf(t)
-
-	// If the type is not a pointer, create a pointer to it.
-	if typeOfT.Kind() != reflect.Ptr {
-		ptrToT := reflect.New(typeOfT)
-		val := ptrToT.Elem().Interface().(node[K, D])
-		return &val
-	}
-
-	val := reflect.New(typeOfT.Elem()).Interface().(node[K, D])
-	return &val
+	return &node[K, D]{}
 }
 
 // getBit returns the value of the bit at position pos in the given node's key.


### PR DESCRIPTION
The original reflection-based code was written to handle a generic case where node[K, D] might be a pointer type, but towards the implementation this node was converged to be always a struct, allowing the simplication as per this commit along with performance improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal allocation mechanism has been optimized to reduce computational overhead and enhance runtime efficiency. This change streamlines how resources are initialized during operation while maintaining full compatibility with existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->